### PR TITLE
Add timing for total ipynbtest run

### DIFF
--- a/ipynbtest/.gitignore
+++ b/ipynbtest/.gitignore
@@ -1,0 +1,1 @@
+version.py

--- a/ipynbtest/ipynbtest.py
+++ b/ipynbtest/ipynbtest.py
@@ -71,6 +71,7 @@ import re
 import argparse
 import uuid
 import difflib
+import time
 
 from Queue import Empty
 
@@ -679,6 +680,7 @@ class IPyKernel(object):
 # ===============================================================================
 
 if __name__ == '__main__':
+    total_start_time = time.time()
     parser = argparse.ArgumentParser(
         description = 'Run all cells in an ipython notebook as a test and ' +
                       'check whether these successfully execute and ' +
@@ -988,8 +990,9 @@ if __name__ == '__main__':
                     break
 
             tv.br()
-            tv.writeln("  testing results")
-            tv.writeln("  ===============")
+            total_run_time = time.time() - total_start_time
+            tv.writeln("  testing results (%5.3f seconds)" % total_run_time)
+            tv.writeln("  ================================")
             if tv.pass_count > 0:
                 tv.writeln("    %3i cells passed [" %
                            tv.pass_count + tv.green('ok') + "]")


### PR DESCRIPTION
Woohoo! First PR on the new repo!

Two little things in this:
- Add a report of the total time for the notebook to the "testing results" header line. There might be a better place to show you -- you tell me if you'd prefer it elsewhere -- but I know I'd like a total time somewhere in the final results summary.
- .gitignore on version.py (which should probably be removed from the repo: it is built during the setuptools install)
